### PR TITLE
Change link to Angular-CLI to official website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Deepjs
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 6.2.3.
+This project was generated with [Angular CLI](https://cli.angular.io/) version 6.2.3.
 
 ## Development server
 


### PR DESCRIPTION
Change link to Angular-CLI to official website seems better for understand what is needed to install and test angular-CLI instead of older github link